### PR TITLE
build: bump quart to fix transitive dep issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "click>=8.0.1",
     "httpx>=0.23.1",
     "hypercorn>=0.14.3",
-    "quart>=0.18.3",
+    "quart>=0.19.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
Bump the quart package to 0.19.4.

Earlier versions of quart were using removed features of werkzeug. Bumping quart to > 0.19 fixes this issue.